### PR TITLE
Utworzenie pliku .htacces dla hostingu home.pl

### DIFF
--- a/.htacces_home_pl
+++ b/.htacces_home_pl
@@ -1,0 +1,23 @@
+# Prevent directory listings
+Options -Indexes
+
+# Prevent visitors from viewing files directly
+<Files "\.(sdb|md|html|txt)$">
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+        Satisfy All
+    </IfModule>
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+</Files>
+
+# URL rewrites
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteRule ^(inc/|themes/|tmp/).*\.(php|html)$ - [F,L]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^ index.php [L]
+</IfModule>


### PR DESCRIPTION
Zmieniona dyrektywa **FilesMatch** na **Files**. Hosting home.pl nie obługuje dyrektywy FilesMatch.
W przypadku strony na hostingu home.pl należy usunąć plik **.htacces**s, a nazwę **.htaccess_home_pl** zmienić na **.htaccess**