### PR TITLE
Fixed gallery thumbnail when image width is smaller than 150px

### DIFF
--- a/inc/modules/galleries/Admin.php
+++ b/inc/modules/galleries/Admin.php
@@ -130,7 +130,7 @@ class Admin extends AdminModule
                 $row['src'] = unserialize($row['src']);
 
                 if (!isset($row['src']['sm'])) {
-                    $row['src']['sm'] = $row['src']['xs'];
+                    $row['src']['sm'] = isset($row['src']['xs']) ? $row['src']['xs'] : $row['src']['lg'];
                 }
 
                 $assign['images'][] = $row;

--- a/inc/modules/galleries/Site.php
+++ b/inc/modules/galleries/Site.php
@@ -39,8 +39,9 @@ class Site extends SiteModule
                 if (count($items)) {
                     foreach ($items as &$item) {
                         $item['src'] = unserialize($item['src']);
+
                         if (!isset($item['src']['sm'])) {
-                            $item['src']['sm'] = $item['src']['xs'];
+                            $item['src']['sm'] = isset($item['src']['xs']) ? $item['src']['xs'] : $item['src']['lg'];
                         }
                     }
 


### PR DESCRIPTION
Fixed issue #11 
If **xs** fallback doesn't exist, sets the thumbnail to **lg** size. 

note:
Don't need to create special statement for **md** value, because if **md** exist, then **sm** also exist. 