### PR TITLE
Fixed a bug, when a tag with the same name as a folder didn't display

### DIFF
--- a/inc/core/lib/Router.php
+++ b/inc/core/lib/Router.php
@@ -61,7 +61,7 @@ class Router
         }
 
         $url = rtrim(dirname($_SERVER["SCRIPT_NAME"]), '/');
-        $url = trim(str_replace($url, '', $_SERVER['PATH_INFO']), '/');
+        $url = trim(preg_replace('#'.$url.'#', '', $_SERVER['PATH_INFO'], 1), '/');
 
         if ($returnPath) {
             return $url;


### PR DESCRIPTION
Issue #49 
There was a problem in the Router.php, in the execute function. There was a function str_replace which replaced all occurrences of the search string, so when the folder and tag had the same name, then tag didn't display, because it was cut. Function str_replace has been replaced by preg_replace with possible replacements set to 1, so it's will be deleting only one match.

This fix should also work for the blog path (./blog/blog/post/....)