### PR TITLE
Reflective XSS in searchbox module

### DIFF
--- a/inc/modules/searchbox/Site.php
+++ b/inc/modules/searchbox/Site.php
@@ -34,6 +34,8 @@
         public function getSearch($phrase, $index = 1)
         {
             $phrase = urldecode($phrase);
+            $phrase = strip_tags ($phrase);
+            $phrase = htmlentities ($phrase);
             $searchTemplate = 'search.html';
             $phraseMinLength = 3;
 


### PR DESCRIPTION
Hello,
in the Searchbox module exists a reflexive XSS vulnerability.

Example:
URL/search/%3C%2Ftitle%3E%3Cscript%3Ealert(1)%3B%3C%2Fscript%3E%3Ctitle%3E

I fixed it.