### PR TITLE
Add support to HTTPS -> HTTP proxying (i.e. Cloudflare SSL)

### DIFF
--- a/inc/core/lib/functions.php
+++ b/inc/core/lib/functions.php
@@ -222,6 +222,7 @@ function url($data = null)
     if ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')
         || isset_or($_SERVER['SERVER_PORT'], null) == 443
         || isset_or($_SERVER['HTTP_X_FORWARDED_PORT'], null) == 443
+        || isset_or($_SERVER['HTTP_X_FORWARDED_PROTO'], null) == 'https'
     ) {
         $protocol = 'https://';
     } else {


### PR DESCRIPTION
Fixes #76 

Cloudflare does not pass **X-Forwarded-Port** header but **X-Forwarded-Proto** only.

When this header it is set `https` and you have **Flexible SSL** enabled it means the request was forwarded from https (visitor -> Cloudflare) to http (Cloudflare -> origin) - i.e.: the forwarded proto is https.

We should pretend the request was received through https locally as well (although it came over http on port 80) or all assets using template vars will be "broken" (using `http://` protocol instead `https://` as observed on visitor's end).

Documentation is [here](https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-).