### PR TITLE
Fix "in" operator in where clause of the QueryBuilder.

### DIFF
--- a/inc/core/lib/QueryBuilder.php
+++ b/inc/core/lib/QueryBuilder.php
@@ -285,12 +285,13 @@ class QueryBuilder
             $value = '(' . implode(',', array_fill(0, count($value), '?')) . ')';
         } else {
             array_push($this->condition_binds, $value);
+            $value = "?";
         }
 
         if (empty($this->conditions) || strpos(end($this->conditions), '(') !== false) {
-            array_push($this->conditions, "$column $operator ?");
+            array_push($this->conditions, "$column $operator $value");
         } else {
-            array_push($this->conditions, "$ao $column $operator ?");
+            array_push($this->conditions, "$ao $column $operator $value");
         }
 
         return $this;


### PR DESCRIPTION
Fixes an error in the query builder where the array values weren't forwarded correctly, making using it with an "in" context not working.

Solves #114 .